### PR TITLE
update action

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,10 +4,15 @@ on:
   push:
     paths-ignore: ['*.md', 'CODEOWNERS', 'LICENSE']
     branches:
-    - 'main'
-    - 'release/*'
+      - 'main'
+      - 'release/*'
   pull_request:
     paths-ignore: ['*.md', 'CODEOWNERS', 'LICENSE']
+
+env:
+  JAVA_VERSION: '11'
+  JAVA_DISTRIBUTION: 'zulu' #This is the default on v1 of the action
+  MAVEN_OPTS: "-Dhttps.protocols=TLSv1.2 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Djava.awt.headless=true"
 
 jobs:
   # Runs the pom sorter and code formatter to ensure that the code
@@ -16,46 +21,30 @@ jobs:
   check-code-formatting:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v1
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
-    - uses: actions/cache@v1
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-format-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-format-
-          ${{ runner.os }}-maven-
-    - name: Format code
-      run: |
-        mvn -V -B -e clean formatter:format sortpom:sort -Pautoformat
-        git status
-        git diff-index --quiet HEAD || (echo "Error! There are modified files after formatting." && false)
-      env:
-        MAVEN_OPTS: "-Dhttps.protocols=TLSv1.2 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Djava.awt.headless=true"
-
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          cache: 'maven'
+      - name: Format code
+        run: |
+          mvn -V -B -e clean formatter:format sortpom:sort -Pautoformat
+          git status
+          git diff-index --quiet HEAD || (echo "Error! There are modified files after formatting." && false)
   # Build the code and run the unit/integration tests.
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v1
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
-    - uses: actions/cache@v1
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-build-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-build-
-          ${{ runner.os }}-maven-format-
-          ${{ runner.os }}-maven-
-    - name: Build and Run Unit Tests
-      run: mvn -V -B -e -Ddist clean verify
-      env:
-        MAVEN_OPTS: "-Dhttps.protocols=TLSv1.2 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Djava.awt.headless=true"
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          cache: 'maven'
+      - name: Build and Run Unit Tests
+        run: mvn -V -B -e -Ddist clean verify


### PR DESCRIPTION
- Update actions versions
- Add zulu distribution
- pull out into env variables
- Switch to `setup-java` maven cache since we are not using cache customization, or caching anything but maven.