### PR TITLE
Allow table cache to be bypassed in WrappedAccumuloClient (#2359)

### DIFF
--- a/src/main/java/datawave/webservice/common/connection/WrappedAccumuloClient.java
+++ b/src/main/java/datawave/webservice/common/connection/WrappedAccumuloClient.java
@@ -57,8 +57,13 @@ public class WrappedAccumuloClient implements AccumuloClient {
     
     @Override
     public BatchScanner createBatchScanner(String tableName, Authorizations authorizations, int numQueryThreads) throws TableNotFoundException {
+        return createBatchScanner(tableName, authorizations, numQueryThreads, false);
+    }
+    
+    public BatchScanner createBatchScanner(String tableName, Authorizations authorizations, int numQueryThreads, boolean skipCache)
+                    throws TableNotFoundException {
         BatchScannerDelegate delegate;
-        if (mock.tableOperations().list().contains(tableName)) {
+        if (!skipCache && mock.tableOperations().list().contains(tableName)) {
             if (log.isTraceEnabled()) {
                 log.trace("Creating mock batch scanner for table: " + tableName);
             }
@@ -82,8 +87,12 @@ public class WrappedAccumuloClient implements AccumuloClient {
     
     @Override
     public BatchScanner createBatchScanner(String tableName, Authorizations authorizations) throws TableNotFoundException {
+        return createBatchScanner(tableName, authorizations, false);
+    }
+    
+    public BatchScanner createBatchScanner(String tableName, Authorizations authorizations, boolean skipCache) throws TableNotFoundException {
         BatchScannerDelegate delegate;
-        if (mock.tableOperations().list().contains(tableName)) {
+        if (!skipCache && mock.tableOperations().list().contains(tableName)) {
             if (log.isTraceEnabled()) {
                 log.trace("Creating mock batch scanner for table: " + tableName);
             }
@@ -107,8 +116,12 @@ public class WrappedAccumuloClient implements AccumuloClient {
     
     @Override
     public BatchScanner createBatchScanner(String tableName) throws TableNotFoundException, AccumuloSecurityException, AccumuloException {
+        return createBatchScanner(tableName, false);
+    }
+    
+    public BatchScanner createBatchScanner(String tableName, boolean skipCache) throws TableNotFoundException, AccumuloSecurityException, AccumuloException {
         BatchScannerDelegate delegate;
-        if (mock.tableOperations().list().contains(tableName)) {
+        if (!skipCache && mock.tableOperations().list().contains(tableName)) {
             if (log.isTraceEnabled()) {
                 log.trace("Creating mock batch scanner for table: " + tableName);
             }
@@ -179,8 +192,12 @@ public class WrappedAccumuloClient implements AccumuloClient {
     
     @Override
     public Scanner createScanner(String tableName, Authorizations authorizations) throws TableNotFoundException {
+        return createScanner(tableName, authorizations, false);
+    }
+    
+    public Scanner createScanner(String tableName, Authorizations authorizations, boolean skipCache) throws TableNotFoundException {
         ScannerDelegate delegate;
-        if (mock.tableOperations().list().contains(tableName)) {
+        if (!skipCache && mock.tableOperations().list().contains(tableName)) {
             if (log.isTraceEnabled()) {
                 log.trace("Creating mock scanner for table: " + tableName);
             }
@@ -203,8 +220,12 @@ public class WrappedAccumuloClient implements AccumuloClient {
     
     @Override
     public Scanner createScanner(String tableName) throws TableNotFoundException, AccumuloSecurityException, AccumuloException {
+        return createScanner(tableName, false);
+    }
+    
+    public Scanner createScanner(String tableName, boolean skipCache) throws TableNotFoundException, AccumuloSecurityException, AccumuloException {
         Scanner delegate;
-        if (mock.tableOperations().list().contains(tableName)) {
+        if (!skipCache && mock.tableOperations().list().contains(tableName)) {
             if (log.isTraceEnabled()) {
                 log.trace("Creating mock batch scanner for table: " + tableName);
             }
@@ -282,5 +303,4 @@ public class WrappedAccumuloClient implements AccumuloClient {
     public void setScanBatchTimeoutSeconds(long scanBatchTimeoutSeconds) {
         this.scanBatchTimeoutSeconds = scanBatchTimeoutSeconds;
     }
-    
 }

--- a/src/main/java/datawave/webservice/common/connection/WrappedScannerHelper.java
+++ b/src/main/java/datawave/webservice/common/connection/WrappedScannerHelper.java
@@ -1,0 +1,40 @@
+package datawave.webservice.common.connection;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.apache.accumulo.core.client.BatchScanner;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.security.Authorizations;
+
+import datawave.security.util.AuthorizationsMinimizer;
+import datawave.security.util.ScannerHelper;
+
+/**
+ * Scanner factory for {@link WrappedAccumuloClient} that allows the table cache to be bypassed, if desired
+ */
+public class WrappedScannerHelper extends ScannerHelper {
+    
+    public static Scanner createScanner(WrappedAccumuloClient connector, String tableName, Collection<Authorizations> authorizations, boolean skipCache)
+                    throws TableNotFoundException {
+        if (authorizations == null || authorizations.isEmpty()) {
+            throw new IllegalArgumentException("Authorizations must not be empty.");
+        }
+        Iterator<Authorizations> iter = AuthorizationsMinimizer.minimize(authorizations).iterator();
+        Scanner scanner = connector.createScanner(tableName, iter.next(), skipCache);
+        addVisibilityFilters(iter, scanner);
+        return scanner;
+    }
+    
+    public static BatchScanner createBatchScanner(WrappedAccumuloClient connector, String tableName, Collection<Authorizations> authorizations,
+                    int numQueryThreads, boolean skipCache) throws TableNotFoundException {
+        if (authorizations == null || authorizations.isEmpty()) {
+            throw new IllegalArgumentException("Authorizations must not be empty.");
+        }
+        Iterator<Authorizations> iter = AuthorizationsMinimizer.minimize(authorizations).iterator();
+        BatchScanner batchScanner = connector.createBatchScanner(tableName, iter.next(), numQueryThreads, skipCache);
+        addVisibilityFilters(iter, batchScanner);
+        return batchScanner;
+    }
+}


### PR DESCRIPTION
The goal here is to allow certain webservice operations (e.g., [ModelBean's delete & import](https://github.com/NationalSecurityAgency/datawave/pull/2362)) to be performed in a more timely manner. As currently implemented here and in the DW webservice, a user is forced wait for a full table cache refresh after a model delete before the subsequent model import can be performed