### PR TITLE
Replace deprecated newInstance()

### DIFF
--- a/src/main/java/datawave/accumulo/util/security/UserAuthFunctions.java
+++ b/src/main/java/datawave/accumulo/util/security/UserAuthFunctions.java
@@ -278,7 +278,7 @@ public interface UserAuthFunctions {
                 return new UserAuthFunctions.Default();
             } else {
                 try {
-                    return (UserAuthFunctions) Class.forName(classOverride).newInstance();
+                    return (UserAuthFunctions) Class.forName(classOverride).getDeclaredConstructor().newInstance();
                 } catch (Throwable t) {
                     throw new RuntimeException(String.format("Failed to create instance of '%s'", classOverride), t);
                 }


### PR DESCRIPTION
clazz.newInstance() is deprecated. 

clazz.newInstance() replaced with clazz.getDeclaredConstructor().newInstance()

part of https://github.com/NationalSecurityAgency/datawave/issues/2443